### PR TITLE
re.ScanString matches a regexp against a string.

### DIFF
--- a/re.go
+++ b/re.go
@@ -113,6 +113,12 @@ func Scan(re *regexp.Regexp, input []byte, output ...interface{}) error {
 	return nil
 }
 
+// ScanString behaves the same as Scan, but it matches the regexp against a
+// string, rather than a byte array.
+func ScanString(re *regexp.Regexp, input string, output ...interface{}) error {
+	return Scan(re, []byte(input), output...)
+}
+
 func assign(r interface{}, b []byte, s Span) error {
 	switch v := r.(type) {
 	case nil:


### PR DESCRIPTION
re.ScanString is a convenience wrapper around re.Scan that converts the argument from []byte to string, so that the user doesn't have to do so. Since String functions in package regexp are used much more frequently than the Bytes functions, removing the fricton of an explicit Bytes conversion from this package should help adoption.

This is a strawman implementation where we simply convert from string to []byte and call Scan. If you want something more optimized, my plan would be to have ScanString duplicate the implementation of String, change assign to take a string as its argument instead of []byte (since most branches do an explicit string conversion anyway), and special-case the few conversion paths where []byte is specifically needed for the output of Scan.